### PR TITLE
グループを検索するAPIを実装

### DIFF
--- a/src/main.go
+++ b/src/main.go
@@ -34,7 +34,7 @@ func main() {
   e.GET("/user/check-login", user.CheckLogin)
   e.POST("/group/register", group.Register)
   e.POST("/group/participate", group.Participate)
-  // e.GET("/group/select", group.Select)
+  e.GET("/group/select", group.Select)
   // e.PATCH("/group/quit", group.Quit)
   e.PATCH("/group/host-update", group.HostUpdate)
   // e.POST("/subject/register", subject.Register)


### PR DESCRIPTION
## Issueへのリンク
resolve: #12 

## やったこと
グループを検索するAPIを実装

## やらないこと
連続でない文字列での検索
例　阿南工業高等専門学校
検索キーワード: 阿南→〇, 阿高→×

## できるようになること
自分の属するグループを検索することができる。

## できなくなること
特になし。

## 動作確認
Postmanで動作確認を行った

## その他(あれば)
特になし。