### PR TITLE
対象授業登録APIを実装

### DIFF
--- a/src/handlers/subject/subject_handler.go
+++ b/src/handlers/subject/subject_handler.go
@@ -20,6 +20,31 @@ type Subjects struct {
 
 // func Register(c echo.Context) error {}
 
+func Target(c echo.Context) error {
+	classId   := c.FormValue("class_id")
+	subjectId := c.FormValue("subject_id")
+
+	// データベースのハンドルを取得
+	db := database.Connect()
+	defer db.Close()
+
+	insert, err := db.Prepare("INSERT INTO lesson_relations(class_id, subject_id) VALUES(?, ?);")
+	if err != nil {
+		log.Fatal(err)
+		return c.NoContent(http.StatusInternalServerError)
+	}
+	defer insert.Close()
+
+	// SQLの実行
+	_, err = insert.Exec(classId, subjectId)
+	if err != nil {
+		log.Fatal(err)
+		return c.NoContent(http.StatusInternalServerError)
+	}
+
+	return c.NoContent(http.StatusCreated)
+}
+
 func LoadSubject(c echo.Context) error {
 	classId := c.QueryParam("class_id")
 
@@ -28,7 +53,7 @@ func LoadSubject(c echo.Context) error {
 	defer db.Close()
 
 	rows, err := db.Query(
-		"SELECT subjects.subject_id, subjects.subject_name FROM subjects NATURAL JOIN lesson_relations WHERE lesson_relations.class_id = ?;",
+		"SELECT subject_id, subject_name FROM subjects NATURAL JOIN lesson_relations WHERE class_id = ?;",
 		classId,
 	)
 	if err != nil {

--- a/src/main.go
+++ b/src/main.go
@@ -52,5 +52,5 @@ func main() {
   // e.PUT("/good", good.Reverse)
 
   // サーバーをポート番号8080で起動
-  e.Logger.Fatal(e.Start(":8081"))
+  e.Logger.Fatal(e.Start(":8080"))
 }

--- a/src/main.go
+++ b/src/main.go
@@ -42,6 +42,7 @@ func main() {
   e.PATCH("/group/quit", group.Quit)
   e.PATCH("/group/host-update", group.HostUpdate)
   // e.POST("/subject/register", subject.Register)
+  e.POST("/subject/target", subject.Target)
   e.GET("/subject/load-subject", subject.LoadSubject)
   e.POST("/evaluation/register", evaluation.Register)
   e.POST("/evaluation/purchase", evaluation.Purchase)
@@ -51,5 +52,5 @@ func main() {
   // e.PUT("/good", good.Reverse)
 
   // サーバーをポート番号8080で起動
-  e.Logger.Fatal(e.Start(":8080"))
+  e.Logger.Fatal(e.Start(":8081"))
 }


### PR DESCRIPTION
## Issueへのリンク
resolve: #43

## やったこと
クラスが対象の授業に登録する処理を実装。

## やらないこと
特になし。

## できるようになること
対象の授業に登録することができる。

## できなくなること
特になし。

## 動作確認
Talend API Testerにより動作確認を行った。

## その他(あれば)
特になし。